### PR TITLE
feat: add macOS (DMG) build support

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -41,3 +41,18 @@ nsis:
   installerIcon: build/icon.ico
   uninstallerIcon: build/icon.ico
   installerHeaderIcon: build/icon.ico
+
+mac:
+  icon: build/icon.png
+  category: public.app-category.graphics-design
+  forceCodeSigning: false
+  identity: null
+  target:
+    - target: dmg
+      arch:
+        - x64
+        - arm64
+
+dmg:
+  artifactName: ${name}-${version}-mac.${ext}
+  title: 魔因漫创

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moyin-creator",
-  "version": "0.1.1",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moyin-creator",
-      "version": "0.1.1",
+      "version": "0.1.7",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@radix-ui/react-context-menu": "^2.2.16",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "electron-vite build && electron-builder --win",
     "prebuild": "powershell -Command \"Stop-Process -Name 'moyin-creator' -ErrorAction SilentlyContinue; Stop-Process -Name '魔因漫创' -ErrorAction SilentlyContinue; Stop-Process -Name 'moyin-creator-*-setup' -ErrorAction SilentlyContinue; if (Test-Path release) { Remove-Item -Recurse -Force release -ErrorAction SilentlyContinue }\"",
     "build:win": "electron-vite build && electron-builder --win",
+    "build:mac": "electron-vite build && electron-builder --mac",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "electron-vite preview"
   },


### PR DESCRIPTION
## 变更说明

本 PR 为项目添加了 macOS 平台的构建支持。

### 变更内容

**`electron-builder.yml`**
- 新增 `mac` 构建目标，输出格式为 DMG
- 同时支持 `x64`（Intel）和 `arm64`（Apple Silicon）两种架构
- 设置 `identity: null` 跳过代码签名（分发时可配置 Apple Developer 证书开启）

**`package.json`**
- 新增 `build:mac` 脚本，方便在 macOS 环境下一键构建

### 构建方法

在 macOS 系统上执行：

```bash
ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/" npm run build:mac
```

构建产物位于 `release/moyin-creator-{version}-mac.dmg`。

### 注意事项

- 未签名的应用首次打开时会触发 Gatekeeper 安全提示，用户可通过右键菜单 → 打开来绕过
- 若需正式签名分发，需配置 `CSC_LINK` 和 `CSC_KEY_PASSWORD` 环境变量并移除 `identity: null`