### PR TITLE
fix: make build scripts cross-platform with auto platform detection

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -18,7 +18,7 @@ asarUnpack:
   - "**/node_modules/sharp/**"
 
 # 图标配置
-icon: build/icon.ico
+icon: build/icon.png
 
 win:
   executableName: moyin-creator
@@ -28,6 +28,17 @@ win:
     - target: nsis
       arch:
         - x64
+
+mac:
+  icon: build/icon.png
+  target:
+    - dmg
+    - zip
+
+linux:
+  icon: build/icon.png
+  target:
+    - AppImage
 
 # NSIS 安装包配置
 nsis:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moyin-creator",
   "productName": "魔因漫创",
-"version": "0.1.7",
+  "version": "0.1.7",
   "description": "AI 驱动的动漫/短剧分镜创作工具",
   "author": "MemeCalculate",
   "license": "AGPL-3.0-or-later",
@@ -16,9 +16,15 @@
   "type": "module",
   "scripts": {
     "dev": "electron-vite dev",
-    "build": "electron-vite build && electron-builder --win",
-    "prebuild": "powershell -Command \"Stop-Process -Name 'moyin-creator' -ErrorAction SilentlyContinue; Stop-Process -Name '魔因漫创' -ErrorAction SilentlyContinue; Stop-Process -Name 'moyin-creator-*-setup' -ErrorAction SilentlyContinue; if (Test-Path release) { Remove-Item -Recurse -Force release -ErrorAction SilentlyContinue }\"",
-    "build:win": "electron-vite build && electron-builder --win",
+    "clean:release": "node ./scripts/clean-release.mjs",
+    "build:app": "electron-vite build",
+    "pack:win": "electron-builder --win",
+    "pack:mac": "electron-builder --mac",
+    "pack:linux": "electron-builder --linux",
+    "build": "node ./scripts/build-by-platform.mjs",
+    "build:win": "npm run clean:release && npm run build:app && npm run pack:win",
+    "build:mac": "npm run clean:release && npm run build:app && npm run pack:mac",
+    "build:linux": "npm run clean:release && npm run build:app && npm run pack:linux",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "electron-vite preview"
   },

--- a/scripts/build-by-platform.mjs
+++ b/scripts/build-by-platform.mjs
@@ -1,0 +1,24 @@
+import { spawnSync } from 'node:child_process'
+
+const buildScriptByPlatform = {
+  win32: 'build:win',
+  darwin: 'build:mac',
+  linux: 'build:linux'
+}
+
+const selectedScript = buildScriptByPlatform[process.platform]
+
+if (!selectedScript) {
+  console.error(`Unsupported platform: ${process.platform}`)
+  process.exit(1)
+}
+
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const child = spawnSync(npmCommand, ['run', selectedScript], { stdio: 'inherit' })
+
+if (child.error) {
+  console.error(child.error.message)
+  process.exit(1)
+}
+
+process.exit(child.status ?? 1)

--- a/scripts/clean-release.mjs
+++ b/scripts/clean-release.mjs
@@ -1,0 +1,28 @@
+import { existsSync, rmSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+
+const processPatterns = ['moyin-creator', '魔因漫创']
+
+function killRunningProcesses() {
+  if (process.platform === 'win32') {
+    for (const pattern of processPatterns) {
+      spawnSync('taskkill', ['/F', '/IM', `${pattern}.exe`], { stdio: 'ignore' })
+    }
+    return
+  }
+
+  for (const pattern of processPatterns) {
+    spawnSync('pkill', ['-f', pattern], { stdio: 'ignore' })
+  }
+}
+
+function cleanReleaseDirectory() {
+  if (!existsSync('release')) {
+    return
+  }
+  rmSync('release', { recursive: true, force: true })
+}
+
+killRunningProcesses()
+cleanReleaseDirectory()
+console.log('Cleaned release directory and attempted to stop running app processes.')


### PR DESCRIPTION
## Summary
- replace Windows-only PowerShell prebuild logic with a cross-platform Node cleanup script
- add platform-aware build routing so npm run build auto-selects build:win / build:mac / build:linux
- split build pipeline into reusable steps (build:app, pack:*) and add explicit scripts for each OS
- update electron-builder config so macOS/Linux use build/icon.png and add mac/linux targets

## Why
Issue #1 reports npm run build fails on macOS/Linux because prebuild hardcodes powershell.

## Verification
Executed on macOS:
- npm run build -> auto-routed to build:mac, succeeded (produced .dmg and .zip)
- npm run build:linux -> succeeded (produced .AppImage)
- npm run build:win -> succeeded (produced setup.exe)

Closes #1